### PR TITLE
Ensure query params are checked if version isn't in Accept header

### DIFF
--- a/eots/negotiation.py
+++ b/eots/negotiation.py
@@ -55,12 +55,22 @@ class AcceptsVersionNegotiator(VersionNegotiator):
     This uses the Accept header but can fallback to the "v" query param.
     """
     def get_version(self, request):
+        version = None
+
+        # Attempt to get version from Accept header
         accepts = request.headers.get("Accept")
         if accepts:
-            accepts, params = parse_header(accepts)
-            return params.get("v")
-        else:
-            return request.arguments["v"][0]
+            _, params = parse_header(accepts)
+            version = params.get('v')
+
+        # Attempt to get version from query params
+        if not version:
+            try:
+                version = request.arguments['v'][0]
+            except (KeyError, TypeError, IndexError):
+                pass
+
+        return version
 
     def select_version(self, request, versions):
         """

--- a/eots/tests/test_negotiation.py
+++ b/eots/tests/test_negotiation.py
@@ -43,10 +43,16 @@ class ContentNegotiatorTest(unittest.TestCase):
 class AcceptsVersionNegotiatorTest(unittest.TestCase):
     def test_get_version(self):
         request = Mock()
+        request.headers = {"Accept": "text/html; v=1"}
+        self.assertEqual("1", AcceptsVersionNegotiator().get_version(request))
+
+    def test_get_version_returns_None_when_no_version_specified(self):
+        request = Mock()
         request.headers = {"Accept": "text/html"}
         self.assertEqual(None, AcceptsVersionNegotiator().get_version(request))
 
-    def test_get_version(self):
+    def test_get_version_will_fallback_to_query_params(self):
         request = Mock()
-        request.headers = {"Accept": "text/html; v=1"}
-        self.assertEqual("1", AcceptsVersionNegotiator().get_version(request))
+        request.headers = {"Accept": "text/html"}
+        request.arguments = {'v': [1]}
+        self.assertEqual(1, AcceptsVersionNegotiator().get_version(request))


### PR DESCRIPTION
Hi @dpnova ,

Fixed a little bug which was preventing the `v=` query param from being checked when the version wasn't specified in sent Accept header.
