### PR TITLE
Added support for basic auth

### DIFF
--- a/eots/client.py
+++ b/eots/client.py
@@ -12,10 +12,11 @@ import json
 class RESTClient(object):
     base_url = None
     version = None
-    def __init__(self, base_url=None, version=None):
+    def __init__(self, base_url=None, version=None, auth=None):
         self.base_url = self.base_url or base_url or ""
         self.version = self.version or version or 0
         self.accept_content_type = "application/json"
+        self.auth = auth
 
     def _full_url(self, path, id=None):
         url = self.base_url + path
@@ -67,6 +68,10 @@ class RESTClient(object):
         headers = self._all_extra_headers()
         new_headers = kwargs.pop("headers", {})
         headers.update(new_headers)
+
+        if self.auth:
+            kwargs['auth'] = self.auth
+
         return treq.request(
             method,
             path,
@@ -81,5 +86,3 @@ class RESTClient(object):
     def _handle_response(self, response):
         return response.json().addCallback(
             lambda content: (response, content))
-
-

--- a/eots/tests/test_client.py
+++ b/eots/tests/test_client.py
@@ -1,0 +1,14 @@
+from mock import patch
+
+from twisted.trial import unittest
+from eots.client import RESTClient
+
+
+class RESTClientTest(unittest.TestCase):
+    @patch('eots.client.treq')
+    def test_auth_is_used_when_passed(self, treq_mock):
+        username, password = 'user', 'hunter2'
+        client = RESTClient('http://base/', auth=(username, password))
+        client.retrieve('resource', 1)
+        args, kwargs = treq_mock.request.call_args
+        self.assertTrue(kwargs['auth'] == (username, password))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cyclone==1.1
 mock==1.0.1
+treq==0.2.1


### PR DESCRIPTION
Hi @dpnova ,

This PR adds preliminary support for Basic Auth by allowing us to pass in a `(user, pass)` tuple into the `RESTClient` constructor which gets fed into `treq.request` as per the [docs](http://treq.readthedocs.org/en/latest/howto.html#auth).
