### PR TITLE
Use _make_request method for all client calls

### DIFF
--- a/eots/client.py
+++ b/eots/client.py
@@ -39,8 +39,11 @@ class RESTClient(object):
         )
 
     def list(self, path, *args, **kwargs):
-        return treq.get(
-            self._full_url(path))
+        return self._make_request(
+            "GET",
+            self._full_url(path),
+            **kwargs
+        )
 
     def update(self, path, id, **kwargs):
         return self._make_request(
@@ -50,18 +53,22 @@ class RESTClient(object):
         )
 
     def delete(self, path, id, *args, **kwargs):
-        return treq.delete(
+        return self._make_request(
+            "DELETE",
             self._full_url(path, id),
-            headers=self._all_extra_headers())
+            **kwargs
+        )
 
     def create(self, path, data, **kwargs):
         path = self._full_url(path)
         return self._make_request("POST", path, data=data, **kwargs)
 
     def info(self, path, id=None, *args, **kwargs):
-        return treq.options(
+        return self._make_request(
+            "OPTIONS",
             self._full_url(path, id),
-            headers=self._all_extra_headers())
+            **kwargs
+        )
 
     def _make_request(self, method, path, data=None, *args, **kwargs):
         data = json.dumps(data) if data is not None else None


### PR DESCRIPTION
Hi @dpnova ,

Can you take a look and let me know what you think? I think this is just fixing up some incomplete stuff, but there might be another reason why we're not using `_make_request` in every client method? Let me know if so.
