### PR TITLE
Check content's truthiness before attempting to decode it.

### DIFF
--- a/eots/client.py
+++ b/eots/client.py
@@ -110,6 +110,7 @@ class RESTClient(object):
         return response.content().addCallback(self.got_content, eots_response)
 
     def got_content(self, content, response):
-        response.complete_content = content
-        response.complete_json = json.loads(content)
+        if content:
+            response.complete_content = content
+            response.complete_json = json.loads(content)
         return response

--- a/eots/negotiation.py
+++ b/eots/negotiation.py
@@ -72,15 +72,17 @@ class AcceptsVersionNegotiator(VersionNegotiator):
 
         return version
 
-    def select_version(self, request, versions):
-        """
-        Return the resource for the current version.
+    def get_default(self, versions):
+        """Get highest version."""
+        return sorted(versions.keys(), reverse=True)[0]
 
-        Potentially we could try and order versions and choose the most
-        up to date one in the situation where a client has simply
-        forgotten to add the version.
-        """
+    def select_version(self, request, versions):
+        """Return the resource for the current version."""
         version = self.get_version(request)
+
+        if not version:
+            return versions[self.get_default(versions)]
+
         try:
             return versions[version]
         except (KeyError, ValueError):


### PR DESCRIPTION
Hi @dpnova,

This stops the client from breaking on 204 response codes with empty payloads.
