### PR TITLE
[axof:432 wl:5hrs] parse the `parameter` values value to utf8

### DIFF
--- a/eots/client.py
+++ b/eots/client.py
@@ -93,7 +93,14 @@ class RESTClient(object):
 
         if self.auth:
             kwargs['auth'] = self.auth
-
+        if kwargs.get('params', {}):
+            params = kwargs.get('params', {})
+            for key, value in params.items():
+                value = utf8(value) if type(value) == str else value
+                params[key] = value
+            if params:
+                kwargs['params'] = params
+        
         return treq.request(
             method,
             path,

--- a/eots/client.py
+++ b/eots/client.py
@@ -4,6 +4,7 @@ A simple client for interacting with a REST interface.
 FIXME: Note hard coded json as request body! We need to fix this.
 """
 from twisted.python import log
+from cyclone.escape import utf8
 import treq
 import json
 
@@ -86,6 +87,7 @@ class RESTClient(object):
         )
 
     def _make_request(self, method, path, data=None, *args, **kwargs):
+        """Parse and create the request object."""
         data = json.dumps(data) if data is not None else None
         headers = self._all_extra_headers()
         new_headers = kwargs.pop("headers", {})
@@ -93,14 +95,16 @@ class RESTClient(object):
 
         if self.auth:
             kwargs['auth'] = self.auth
+
         if kwargs.get('params', {}):
             params = kwargs.get('params', {})
+
             for key, value in params.items():
-                value = utf8(value) if type(value) == str else value
+                value = utf8(value) if isinstance(value, basestring) else value
                 params[key] = value
             if params:
                 kwargs['params'] = params
-        
+
         return treq.request(
             method,
             path,

--- a/eots/tests/test_client.py
+++ b/eots/tests/test_client.py
@@ -1,3 +1,7 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""Test the eots client module."""
 from mock import patch, Mock
 
 from twisted.trial import unittest
@@ -5,17 +9,38 @@ from eots.client import RESTClient, EOTSResponse
 
 
 class RESTClientTest(unittest.TestCase):
+    """Test basic authentication in eots."""
+
     @patch('eots.client.treq')
     def test_auth_is_used_when_passed(self, treq_mock):
+        """Test succesful user authentication."""
         username, password = 'user', 'hunter2'
         client = RESTClient('http://base/', auth=(username, password))
         client.retrieve('resource', 1)
         args, kwargs = treq_mock.request.call_args
         self.assertTrue(kwargs['auth'] == (username, password))
 
+    @patch('eots.client.treq')
+    def test_utf8(self, treq_mock):
+        """Test succesful user authentication."""
+        username, password = 'user', 'hunter2'
+        client = RESTClient(
+            'http://base/',
+            auth=(username, password),
+        )
+        client.list(
+            'resource',
+            params={'search': u"pijamalı hasta yağız şoföre çabucak güvendi"}
+        )
+        args, kwargs = treq_mock.request.call_args
+        self.assertTrue(kwargs['auth'] == (username, password))
+
 
 class EOTSResponseTest(unittest.TestCase):
+    """Test the eots reponse for a request."""
+
     def test_get_complete_content(self):
+        """Test succesful content acquisition."""
         response = Mock()
         response.content = "none"
         er = EOTSResponse(response)


### PR DESCRIPTION
currently when parameter value with non latin characters is sent to treq.request as a url parameter the treq parser changes the non latin characters into '?' so 'Şişli' becomes '?i?li'. this changes the parameters values into encoded strings.